### PR TITLE
Removing fontawesome haykal  since it now creates a build error.

### DIFF
--- a/lib/icons_helper.dart
+++ b/lib/icons_helper.dart
@@ -1753,7 +1753,6 @@ const Map<String, IconData> FontAwesomeIconsMap = <String, IconData>{
   'hardHat': FontAwesomeIcons.hardHat,
   'hashtag': FontAwesomeIcons.hashtag,
   'hatWizard': FontAwesomeIcons.hatWizard,
-  'haykal': FontAwesomeIcons.haykal,
   'hdd': FontAwesomeIcons.hdd,
   'solidHdd': FontAwesomeIcons.solidHdd,
   'heading': FontAwesomeIcons.heading,


### PR DESCRIPTION
Removing fontawesome haykal  since it now creates a build error.
Fowtawesome removed the font. 
This fix just removes the line causing the build error. 
A better longterm solution might be to skip the ^ on the fontawesome version since this library is very sensitive to changes.